### PR TITLE
fix incorrect status parameter in record

### DIFF
--- a/backstage/src/main/resources/templates/admin/processHistoryList.html
+++ b/backstage/src/main/resources/templates/admin/processHistoryList.html
@@ -198,8 +198,8 @@
         if(originaladdress != "" ){
             option['originaladdress']= originaladdress;
         }
-        var  status = $('.status').val();
-        if(videoplatform != "" ){
+        var  status = $('#status').val();
+        if(status != "" ){
             option['status']= status;
         }
         $.post("/admin/api/findProcessHistoryList",option,


### PR DESCRIPTION
Fixed incorrect `status` check in query that caused it to be omitted from backend requests.