### PR TITLE
remove deprecated ytdlpargs setting from config.html

### DIFF
--- a/backstage/src/main/java/com/flower/spirit/entity/ConfigEntity.java
+++ b/backstage/src/main/java/com/flower/spirit/entity/ConfigEntity.java
@@ -56,7 +56,7 @@ public class ConfigEntity implements Serializable {
 	
 	private String ytdlpmode;
 	
-	private String ytdlpargs;
+	// private String ytdlpargs;
 	
 	private String nfonetaddr;
 	
@@ -198,13 +198,13 @@ public class ConfigEntity implements Serializable {
 		this.danmudown = danmudown;
 	}
 
-	public String getYtdlpargs() {
-		return ytdlpargs;
-	}
+	// public String getYtdlpargs() {
+	// 	return ytdlpargs;
+	// }
 
-	public void setYtdlpargs(String ytdlpargs) {
-		this.ytdlpargs = ytdlpargs;
-	}
+	// public void setYtdlpargs(String ytdlpargs) {
+	// 	this.ytdlpargs = ytdlpargs;
+	// }
 
 	
 	

--- a/backstage/src/main/resources/templates/admin/config.html
+++ b/backstage/src/main/resources/templates/admin/config.html
@@ -138,12 +138,12 @@
                                                 </select>
                                             </div>
                                         </div>
-                                        <div class="col-md-6">
+                                        <!-- <div class="col-md-6">
                                             <div class="form-group">
                                                 <label>YT-DLP 参数追加 <i class="mdi mdi-help" style="cursor: pointer; font-size: 12px;" onclick="layer.alert('需要熟悉了解yt-dlp,请不要追加已存在的参数.如不熟悉当前项目 请保持为空<br/>错误的参数追加可能会造成yt-dlp相关平台的下载错误<br/>追加格式为-xxxx vlaue -xxxx value -value') "></i></label>
                                                 <input class="form-control" type="text" id="ytdlpargs" name="ytdlpargs" placeholder="无特殊情况,保持为空" th:value="${config.ytdlpargs}">
                                             </div>
-                                        </div>
+                                        </div> -->
                                         <div class="col-md-6">
                                             <div class="form-group">
                                                 <label>分片下载 <i class="mdi mdi-help" style="cursor: pointer; font-size: 12px;" onclick="layer.alert('无特殊情况建议默认为1,不分片') "></i></label>
@@ -550,7 +550,6 @@
               option['rangenum'] = $("#rangenum").val();
               option['frontend'] = $("#frontend").val();
               option['danmudown'] = $("#danmudown").val();
-              option['ytdlpargs'] = $("#ytdlpargs").val();
               $.post("/admin/api/saveConfig",option,function(data,status){
                   if(data.resCode =="000001"){
                       layer.closeAll();
@@ -709,7 +708,6 @@
             option['rangenum'] = $("#rangenum").val();
             option['frontend'] = $("#frontend").val();
             option['danmudown'] = $("#danmudown").val();
-            option['ytdlpargs'] = $("#ytdlpargs").val();
             $.post("/admin/api/saveConfig",option,function(data,status){
                 if(data.resCode =="000001"){
                     layer.closeAll();


### PR DESCRIPTION
The ytdlpargs parameter is obsolete but was still present in config.html, which could mislead users. Removed the setting to avoid confusion.