### PR TITLE
perf: enable SQLite WAL mode to improve concurrency

### DIFF
--- a/backstage/src/main/resources/application-docker.properties
+++ b/backstage/src/main/resources/application-docker.properties
@@ -40,7 +40,7 @@ spring.mvc.static-path-pattern=/static/**
 ## docker \u90E8\u7F72\u90E8\u5206  docker  \u9700\u8981\u5C06 
 spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:sqlite:/app/db/spirit.db
+spring.datasource.url=jdbc:sqlite:/app/db/spirit.db?journal_mode=WAL&busy_timeout=10000
 spring.datasource.driver-class-name=org.sqlite.JDBC
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl


### PR DESCRIPTION
### Changes / 修改内容
Updated `spring.datasource.url` to include `journal_mode=WAL` and `busy_timeout=10000`.
在数据库连接配置中增加了 WAL 模式和超时设置。

### Reason / 原因
Enabling WAL mode supports read-write separation and improves performance, specifically avoiding database locking issues during high-frequency write operations.
开启 WAL 模式支持读写分离，提升性能，特别是在高频写入场景下，避免出现锁库问题。