### PR TITLE
 Improve SQLite WAL support and fix config issues

### DIFF
--- a/backstage/src/main/java/com/flower/spirit/service/DatabaseFinalizerService.java
+++ b/backstage/src/main/java/com/flower/spirit/service/DatabaseFinalizerService.java
@@ -1,0 +1,45 @@
+package com.flower.spirit.service;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+
+@Service
+public class DatabaseFinalizerService {
+
+    private static final Logger log = LoggerFactory.getLogger(DatabaseFinalizerService.class);
+
+    @Autowired
+    private DataSource dataSource;
+
+    @PreDestroy
+    public void onApplicationShutdown() {
+        log.info("应用正在停止,正在准备触发数据库回写..");
+        try {
+            ensureDataPersisted();
+            log.info("数据库回写成功,应用正常退出");
+        } catch (Exception e) {
+            log.warn("数据回写失败,应用退出可能存在异常", e);
+        }
+    }
+
+
+    /**
+     * @throws SQLException
+     */
+    public void ensureDataPersisted() throws SQLException {
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("PRAGMA wal_checkpoint(FULL)");
+        }
+    }
+}

--- a/backstage/src/main/resources/application-docker.properties
+++ b/backstage/src/main/resources/application-docker.properties
@@ -3,6 +3,9 @@
 server.version=0.0.5
 server.port=28081
 
+server.shutdown=graceful
+server.shutdown.grace-period=90s
+
 app.name=spirit
 spring.application.name=spirit
 
@@ -44,13 +47,13 @@ spring.datasource.url=jdbc:sqlite:/app/db/spirit.db
 spring.datasource.driver-class-name=org.sqlite.JDBC
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.datasource.hikari.connection-init-sql=PRAGMA wal_autocheckpoint=20
 
 
-
-file.save.path:/app/resources
-file.app.path:/app/
-file.save.staticAccessPath:/cos/**
-file.save:/cos
+file.save.path=/app/resources
+file.app.path=/app/
+file.save.staticAccessPath=/cos/**
+file.save=/cos
 
 
 # Quartz \u914D\u7F6E


### PR DESCRIPTION
Ensure full database flush when app shuts down in SQLite WAL mode.  
在 SQLite WAL 模式下，应用关闭时把所有数据完整回写到磁盘。

Now explicitly triggers a WAL checkpoint and sync on shutdown.  
现在会在关闭时主动触发 WAL checkpoint 并同步数据。

Also corrected a typo in application-docker.properties,  
顺手改了 application-docker.properties 里一个配置写错的地方。

added graceful shutdown support,  
加了优雅关闭支持，

and set Hikari’s connection-init-sql to PRAGMA wal_autocheckpoint=20 so WAL checkpoints happen more promptly.  
Hikari 初始化 SQL：PRAGMA wal_autocheckpoint=20，让 WAL 自动 checkpoint 更及时。